### PR TITLE
Added BeforeAutoFitColumnWidthEvent that can be run before auto size columns

### DIFF
--- a/ReoGrid/Core/Header.cs
+++ b/ReoGrid/Core/Header.cs
@@ -800,7 +800,17 @@ namespace unvell.ReoGrid
 				throw new ArgumentOutOfRangeException("col");
 			}
 
-			RGFloat maxWidth = 0;
+            if (BeforeAutoFitColumnWidth != null)
+            {
+                var before_arg = new BeforeAutoFitColumnWidthEventArgs(col, 1);
+                BeforeAutoFitColumnWidth(this, before_arg);
+                if (before_arg.IsCancelled)
+                {
+                    return before_arg.WidthChanged;
+                }
+            }
+
+            RGFloat maxWidth = 0;
 
 			for (int r = 0; r <= this.MaxContentRow; r++)
 			{
@@ -2986,8 +2996,13 @@ namespace unvell.ReoGrid
 		/// </summary>
 		public event EventHandler<ColumnsWidthChangedEventArgs> ColumnsWidthChanged;
 
-		#endregion // Events
-	}
+        /// <summary>
+        /// Event raised before a column's width is auto changed.
+        /// </summary>
+        public event EventHandler<BeforeAutoFitColumnWidthEventArgs> BeforeAutoFitColumnWidth;
+
+        #endregion // Events
+    }
 
 	#region Header Defines
 	/// <summary>

--- a/ReoGrid/Core/Header.cs
+++ b/ReoGrid/Core/Header.cs
@@ -800,16 +800,6 @@ namespace unvell.ReoGrid
 				throw new ArgumentOutOfRangeException("col");
 			}
 
-            if (BeforeAutoFitColumnWidth != null)
-            {
-                var before_arg = new BeforeAutoFitColumnWidthEventArgs(col, 1);
-                BeforeAutoFitColumnWidth(this, before_arg);
-                if (before_arg.IsCancelled)
-                {
-                    return before_arg.WidthChanged;
-                }
-            }
-
             RGFloat maxWidth = 0;
 
 			for (int r = 0; r <= this.MaxContentRow; r++)
@@ -853,7 +843,17 @@ namespace unvell.ReoGrid
 				}
 			}
 
-			if (maxWidth > 0)
+            if (BeforeAutoFitColumnWidth != null)
+            {
+                var before_arg = new BeforeAutoFitColumnWidthEventArgs(col, 1, (int)maxWidth);
+                BeforeAutoFitColumnWidth(this, before_arg);
+                if (before_arg.IsCancelled)
+                {
+                    return before_arg.WidthChanged;
+                }
+            }
+
+            if (maxWidth > 0)
 			{
 				if (maxWidth < 0) maxWidth = 0;
 				if (maxWidth > ushort.MaxValue - 2) maxWidth = ushort.MaxValue - 2;

--- a/ReoGrid/EventArgs.cs
+++ b/ReoGrid/EventArgs.cs
@@ -733,7 +733,7 @@ namespace unvell.ReoGrid.Events
 		}
 	}
 
-    public class BeforeAutoFitColumnWidthEventArgs : WorksheetColumnsEventArgs
+    public class BeforeAutoFitColumnWidthEventArgs : ColumnsWidthChangedEventArgs
     {
         /// <summary>
         /// Whether to cancel current auto fit operation.
@@ -750,8 +750,8 @@ namespace unvell.ReoGrid.Events
         /// </summary>
         /// <param name="index">number of column start to adjust</param>
         /// <param name="count">number of columns to adjust</param>
-        public BeforeAutoFitColumnWidthEventArgs(int index, int count)
-            : base(index, count)
+        public BeforeAutoFitColumnWidthEventArgs(int index, int count, int width)
+            : base(index, count, width)
         {
         }
     }

--- a/ReoGrid/EventArgs.cs
+++ b/ReoGrid/EventArgs.cs
@@ -733,14 +733,37 @@ namespace unvell.ReoGrid.Events
 		}
 	}
 
-	#endregion // Column Changes
+    public class BeforeAutoFitColumnWidthEventArgs : WorksheetColumnsEventArgs
+    {
+        /// <summary>
+        /// Whether to cancel current auto fit operation.
+        /// </summary>
+        public bool IsCancelled { get; set; }
 
-	#region Border Changes
+        /// <summary>
+        /// Whether the width was changed.
+        /// </summary>
+        public bool WidthChanged { get; set; }
 
-	/// <summary>
-	/// Event raised on border added to a range.
-	/// </summary>
-	public class BorderAddedEventArgs : RangeEventArgs
+        /// <summary>
+        /// Create before auto fit column width event argument
+        /// </summary>
+        /// <param name="index">number of column start to adjust</param>
+        /// <param name="count">number of columns to adjust</param>
+        public BeforeAutoFitColumnWidthEventArgs(int index, int count)
+            : base(index, count)
+        {
+        }
+    }
+
+    #endregion // Column Changes
+
+    #region Border Changes
+
+    /// <summary>
+    /// Event raised on border added to a range.
+    /// </summary>
+    public class BorderAddedEventArgs : RangeEventArgs
 	{
 		/// <summary>
 		/// Position of border added.


### PR DESCRIPTION
Added to allow us to set the column widths ourselves when the user double clicks on the line between columns